### PR TITLE
Spawn Static should support "random"

### DIFF
--- a/WAI/compile/spawn_static.sqf
+++ b/WAI/compile/spawn_static.sqf
@@ -25,6 +25,7 @@ local _pack = _backpack;
 		} else {
 			if (_skin == "hero") exitWith {WAI_HeroSkin call BIS_fnc_selectRandom;};
 			if (_skin == "bandit") exitWith {WAI_BanditSkin call BIS_fnc_selectRandom;};
+			if (_skin == "random") exitWith {WAI_AllSkin call BIS_fnc_selectRandom;};
 			_skin;
 		};
 	};


### PR DESCRIPTION
https://github.com/worldwidesorrow/WICKED-AI/blob/master/WAI/missions/MISSION_EXAMPLE.sqf#L152 This line says spawn static supports "random" skin but it doesn't truly, causing errors when the server attempts to create the AI who control the turrets.