### PR TITLE
Update staticMissionMonitor.sqf - Fixing error when _enableMarkers is…

### DIFF
--- a/WAI/static/compile/staticMissionMonitor.sqf
+++ b/WAI/static/compile/staticMissionMonitor.sqf
@@ -28,7 +28,12 @@ local _clear = false;
 local _running = true;
 local _time = diag_tickTime;
 local _text = "";
-local _markers = DZE_ServerMarkerArray select _markerIndex;
+local _markers = [];
+if (_enableMarkers) then {
+	_markers = DZE_ServerMarkerArray select _markerIndex;
+} else {
+	_markers = [];
+};
 local _aiCount = (WAI_MissionData select _mission) select 0;
 local _crates = (WAI_MissionData select _mission) select 2;
 local _aiVehicles = (WAI_MissionData select _mission) select 3;


### PR DESCRIPTION
… false

When `_enableMarkers` is false in a static mission, the `_markerIndex` is left as -1 and the `_markers` array is empty. When you try to select -1 on the _markers array, you get a "Error Zero divisor" error.